### PR TITLE
Install EF Core SQLite persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # todoCodexPoc
+
+This repo demonstrates a simple .NET MAUI application with an Entity Framework Core SQLite backend.
+
+## EF Core migrations
+
+The `dotnet` CLI is required to run EF Core commands. If `dotnet` is installed, you can create the initial database with:
+
+```bash
+cd TodoMauiApp
+ dotnet ef migrations add Init
+ dotnet ef database update
+```
+
+In the Codex test environment `dotnet` is not available, so these commands fail. They will work on a local machine that has the .NET SDK installed.

--- a/TodoMauiApp/Data/TaskDbContext.cs
+++ b/TodoMauiApp/Data/TaskDbContext.cs
@@ -1,0 +1,13 @@
+using Microsoft.EntityFrameworkCore;
+using TodoMauiApp.Models;
+
+namespace TodoMauiApp.Data;
+
+public class TaskDbContext : DbContext
+{
+    public TaskDbContext(DbContextOptions<TaskDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<TodoItem> TodoItems => Set<TodoItem>();
+}

--- a/TodoMauiApp/Models/TodoItem.cs
+++ b/TodoMauiApp/Models/TodoItem.cs
@@ -1,0 +1,1 @@
+public record TodoItem(int Id,string Title,DateTimeOffset? DueDate,bool IsDone,int Priority);

--- a/TodoMauiApp/TodoMauiApp.csproj
+++ b/TodoMauiApp/TodoMauiApp.csproj
@@ -8,4 +8,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add EF Core package references in csproj
- add simple TodoItem record
- add TaskDbContext exposing TodoItems
- document EF Core migration steps and lack of dotnet CLI

## Testing
- `dotnet ef migrations add Init` *(fails: `dotnet: command not found`)*
- `dotnet ef database update` *(fails: `dotnet: command not found`)*