### PR TITLE
Add file-based todo repository

### DIFF
--- a/Models/TodoItem.cs
+++ b/Models/TodoItem.cs
@@ -1,0 +1,10 @@
+namespace TodoCodexPoc.Models;
+
+public class TodoItem
+{
+    public Guid Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public DateTimeOffset? DueDate { get; set; }
+    public bool IsDone { get; set; }
+    public int Priority { get; set; }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,32 @@
+using TodoCodexPoc.Models;
+using TodoCodexPoc.Services;
+
 internal class Program
 {
-    private static void Main()
+    private static async Task Main()
     {
+        ITodoRepository repo = new FileTodoRepository();
+        var items = await repo.GetAllAsync();
+
+        if (!items.Any())
+        {
+            var sample = new TodoItem
+            {
+                Id = Guid.NewGuid(),
+                Title = "Sample Task",
+                DueDate = DateTimeOffset.UtcNow.AddDays(1),
+                Priority = 1,
+                IsDone = false
+            };
+            await repo.AddAsync(sample);
+            Console.WriteLine($"Added sample item: {sample.Title}");
+        }
+        else
+        {
+            foreach (var item in items)
+            {
+                Console.WriteLine($"- {item.Title} (done: {item.IsDone})");
+            }
+        }
     }
 }

--- a/Services/FileTodoRepository.cs
+++ b/Services/FileTodoRepository.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using TodoCodexPoc.Models;
+
+namespace TodoCodexPoc.Services;
+
+public class FileTodoRepository : ITodoRepository
+{
+    private readonly string _filePath;
+    private readonly SemaphoreSlim _mutex = new(1, 1);
+    private List<TodoItem>? _items;
+
+    public FileTodoRepository(string? filePath = null)
+    {
+        _filePath = filePath ?? Path.Combine(".", "data", "tasks.json");
+    }
+
+    private async Task<List<TodoItem>> LoadAsync()
+    {
+        if (_items != null)
+        {
+            return _items;
+        }
+
+        await _mutex.WaitAsync();
+        try
+        {
+            if (_items != null)
+            {
+                return _items;
+            }
+
+            if (!File.Exists(_filePath))
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(_filePath)!);
+                _items = new List<TodoItem>();
+                await SaveInternalAsync();
+            }
+            else
+            {
+                using FileStream stream = File.OpenRead(_filePath);
+                _items = await JsonSerializer.DeserializeAsync<List<TodoItem>>(stream) ?? new List<TodoItem>();
+            }
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+
+        return _items;
+    }
+
+    private async Task SaveInternalAsync()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_filePath)!);
+        using FileStream stream = File.Create(_filePath);
+        await JsonSerializer.SerializeAsync(stream, _items, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    public async Task<IReadOnlyList<TodoItem>> GetAllAsync(CancellationToken token = default)
+    {
+        var list = await LoadAsync();
+        return list.AsReadOnly();
+    }
+
+    public async Task<TodoItem?> GetAsync(Guid id, CancellationToken token = default)
+    {
+        var list = await LoadAsync();
+        return list.FirstOrDefault(i => i.Id == id);
+    }
+
+    public async Task AddAsync(TodoItem item, CancellationToken token = default)
+    {
+        var list = await LoadAsync();
+        await _mutex.WaitAsync(token);
+        try
+        {
+            list.Add(item);
+            await SaveInternalAsync();
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    public async Task UpdateAsync(TodoItem item, CancellationToken token = default)
+    {
+        var list = await LoadAsync();
+        await _mutex.WaitAsync(token);
+        try
+        {
+            var index = list.FindIndex(t => t.Id == item.Id);
+            if (index >= 0)
+            {
+                list[index] = item;
+            }
+            await SaveInternalAsync();
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    public async Task DeleteAsync(Guid id, CancellationToken token = default)
+    {
+        var list = await LoadAsync();
+        await _mutex.WaitAsync(token);
+        try
+        {
+            list.RemoveAll(t => t.Id == id);
+            await SaveInternalAsync();
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+}

--- a/Services/ITodoRepository.cs
+++ b/Services/ITodoRepository.cs
@@ -1,0 +1,12 @@
+using TodoCodexPoc.Models;
+
+namespace TodoCodexPoc.Services;
+
+public interface ITodoRepository
+{
+    Task<IReadOnlyList<TodoItem>> GetAllAsync(CancellationToken token = default);
+    Task<TodoItem?> GetAsync(Guid id, CancellationToken token = default);
+    Task AddAsync(TodoItem item, CancellationToken token = default);
+    Task UpdateAsync(TodoItem item, CancellationToken token = default);
+    Task DeleteAsync(Guid id, CancellationToken token = default);
+}


### PR DESCRIPTION
## Summary
- add TodoItem POCO model
- define `ITodoRepository` CRUD interface
- implement thread-safe `FileTodoRepository` backed by tasks.json
- update `Program.cs` to seed sample item and list tasks

## Testing
- `bash`: `dotnet --version` *(fails: command not found)*