### PR TITLE
Add build instructions and offline steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,44 @@
 # todoCodexPoc
 
-This repo demonstrates a simple .NET MAUI application with an Entity Framework Core SQLite backend.
+This repo demonstrates a simple .NET console and MAUI application with an Entity Framework Core SQLite backend.
+
+## Local prerequisites
+
+- .NET SDK 8.0 installed locally. The container used in Codex testing does not include the SDK and has no internet access.
+
+## Building and running
+
+Build and run the console project locally with:
+
+```bash
+dotnet run --project TaskTracker.csproj [verb] [arguments]
+```
+
+Running with no verb lists all tasks.
+
+### CLI verbs
+
+- `add "task description"` &ndash; add a new task. Natural language due dates are parsed automatically.
+- `voice` &ndash; transcribe speech using `IVoiceToText` and create a task from the result.
+
+## Running tests
+
+The tests live under `tests/TaskTracker.Tests`. Execute them locally with:
+
+```bash
+dotnet test
+```
 
 ## EF Core migrations
 
-The `dotnet` CLI is required to run EF Core commands. If `dotnet` is installed, you can create the initial database with:
+The MAUI app relies on Entity Framework Core. After installing the SDK you can create the initial database and schema with:
 
 ```bash
 cd TodoMauiApp
- dotnet ef migrations add Init
- dotnet ef database update
+dotnet ef migrations add Init
+dotnet ef database update
 ```
 
-In the Codex test environment `dotnet` is not available, so these commands fail. They will work on a local machine that has the .NET SDK installed.
+## Why no `dotnet` commands in container prompts?
+
+The container environment lacks the .NET SDK and has no network access. Any `dotnet` commands will fail here, so migrations and tests must be executed on a machine where the SDK is available.

--- a/localaitask.txt
+++ b/localaitask.txt
@@ -1,0 +1,13 @@
+# Commands for the local AI to install dependencies
+# These steps assume offline packages for .NET SDK 8.0 are available.
+
+# 1. Copy the .NET SDK 8.0 installation files into the container, e.g. under /tmp/dotnet.
+# 2. Install the packages. For Debian based systems it may look like:
+# sudo dpkg -i /tmp/dotnet/*.deb
+# 3. Verify the installation:
+# dotnet --version
+
+# Once the SDK is installed you can run:
+# dotnet restore
+# dotnet build
+# dotnet test


### PR DESCRIPTION
## Summary
- document local prerequisites and CLI usage
- explain EF Core setup and absence of `dotnet` in the container
- add offline installation steps for the AI assistant

## Testing
- `dotnet test` *(fails: command not found)*